### PR TITLE
Add a way to collect custom Resque metrics (e.g. provided by plugins)

### DIFF
--- a/resque_exporter/__init__.py
+++ b/resque_exporter/__init__.py
@@ -39,7 +39,7 @@ def main():
     parser.add_argument('-p', '--port', dest='port', type=int,
                         default=os.getenv('RESQUE_EXPORTER_PORT', "9447"),
                         help="Port to expose metrics")
-    parser.add_argument('-l', '--loglevel', dest='loglevel', choices=['INFO, DEBUG'],
+    parser.add_argument('-l', '--loglevel', dest='loglevel', choices=['INFO', 'DEBUG'],
                         default="INFO", help="Set application loglevel INFO, DEBUG")
     parser.add_argument('--custom-metrics', type=json_cmdline_value,
                         default=os.getenv('RESQUE_EXPORTER_CUSTOM_METRICS', None),

--- a/resque_exporter/__init__.py
+++ b/resque_exporter/__init__.py
@@ -1,8 +1,9 @@
-import os
-import sys
-import logging
-import signal
 import argparse
+import json
+import logging
+import os
+import signal
+import sys
 from time import sleep
 
 from prometheus_client import start_http_server
@@ -14,6 +15,12 @@ from .collector import ResqueCollector
 def sigterm_handler():
     logging.info("Shutting down.")
     sys.exit(os.EX_OK)
+
+
+def json_cmdline_value(val):
+    if not val:
+        return None
+    return json.loads(val)
 
 
 def main():
@@ -34,6 +41,14 @@ def main():
                         help="Port to expose metrics")
     parser.add_argument('-l', '--loglevel', dest='loglevel', choices=['INFO, DEBUG'],
                         default="INFO", help="Set application loglevel INFO, DEBUG")
+    parser.add_argument('--custom-metrics', type=json_cmdline_value,
+                        default=os.getenv('RESQUE_EXPORTER_CUSTOM_METRICS', None),
+                        help=(
+                            'Custom metrics to collect, e.g. '
+                            '[{"type": "counter", "name": "mymetric",'
+                            ' "redis_matcher": "mymetric:*", '
+                            '"label_regex": "mymetric:(?P<mykey>.*)$"}]'
+                        ))
     args = parser.parse_args()
 
     numeric_level = getattr(logging, args.loglevel)
@@ -42,7 +57,11 @@ def main():
     start_http_server(args.port, addr=args.addr)
     logging.info(f"HTTP server started on {args.addr}:{args.port}")
 
-    r_collector = ResqueCollector(args.redis_url, namespace=args.redis_ns)
+    r_collector = ResqueCollector(
+        args.redis_url,
+        namespace=args.redis_ns,
+        custom_metrics=args.custom_metrics,
+    )
 
     REGISTRY.register(r_collector)
 


### PR DESCRIPTION
This PR adds a way to specify custom metrics to be collected, e.g.
```
RESQUE_EXPORTER_CUSTOM_METRICS='[{"type": "counter", "name": "mymetric","redis_matcher": "mymetric:*","label_regex": "mymetric:(?P<mykey>.*)$"}]'
```

Set of labels is extracted from `label_regex`'s named groups.