### PR TITLE
Optimize wildcard lookup to avoid timeouts

### DIFF
--- a/resque_exporter/__init__.py
+++ b/resque_exporter/__init__.py
@@ -12,7 +12,7 @@ from prometheus_client.core import REGISTRY
 from .collector import ResqueCollector
 
 
-def sigterm_handler():
+def sigterm_handler(_signo, _stackframe):
     logging.info("Shutting down.")
     sys.exit(os.EX_OK)
 

--- a/resque_exporter/collector.py
+++ b/resque_exporter/collector.py
@@ -51,9 +51,7 @@ class RedisWildcardLookup:
         self._ensure_bg_thread_is_alive()
         self._match_cache.setdefault(pattern, None)
         cached_val = self._match_cache[pattern]
-        if cached_val is not None:
-            return cached_val
-        return list(self._fetch_keys(pattern))
+        return cached_val or []
 
     def _fetch_keys(self, pattern):
         yield from self.redis.scan_iter(match=pattern)


### PR DESCRIPTION
This PR avoids timeouts & extra strain on the Redis instance when wildcard lookup takes too long. It is based on #2 and should be merged after it.

Firstly, it implements `describe` function so that prometheus does not have to evaluate/fetch metrics to generate their description.

Secondly, now custom wildcard metrics are not returned with `/metrics` request until they have been fetched by the background thread. This makes the custom metrics unavailable for the first 60s after the first request to `/metrics`, but it makes sure prometheus is never waiting for the results and times out: the data is either there or not.